### PR TITLE
Set the originalError property on WLValidationErrors

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -1151,6 +1151,11 @@ module.exports = (function() {
       var matches = err.detail.match(/Key \((.*)\)=\((.*)\) already exists\.$/);
       if (matches && matches.length) {
         formattedErr = {};
+        // Preserve the original Postgres error. This property is set for
+        // WLErrors, but not currently for WLValidationErrors. It gets passed
+        // through and set on the error object in the callback to the error
+        // function
+        formattedErr.originalError = err;
         formattedErr.code = 'E_UNIQUE';
         formattedErr.invalidAttributes = {};
         formattedErr.invalidAttributes[matches[1]] = [{


### PR DESCRIPTION
See the comment for more info - this ensures that all errors raised by Postgres
have an originalError property with the Postgres error data.
