### PR TITLE
Lock down versions in package.json

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,86 +1,57 @@
 {
   "name": "sails-postgresql",
-  "version": "0.10.14",
+  "version": "0.10.15",
   "dependencies": {
     "async": {
-      "version": "0.9.0",
-      "from": "async@>=0.9.0 <0.10.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+      "version": "0.9.0"
     },
     "lodash": {
-      "version": "2.4.1",
-      "from": "lodash@>=2.4.1 <2.5.0",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+      "version": "2.4.1"
     },
     "pg": {
       "version": "4.2.0",
-      "from": "pg@>=4.2.0 <4.3.0",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-4.2.0.tgz",
       "dependencies": {
         "buffer-writer": {
-          "version": "1.0.0",
-          "from": "buffer-writer@1.0.0",
-          "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-1.0.0.tgz"
+          "version": "1.0.0"
         },
         "generic-pool": {
-          "version": "2.1.1",
-          "from": "generic-pool@2.1.1",
-          "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.1.1.tgz"
+          "version": "2.1.1"
         },
         "packet-reader": {
-          "version": "0.2.0",
-          "from": "packet-reader@0.2.0",
-          "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-0.2.0.tgz"
+          "version": "0.2.0"
         },
         "pg-connection-string": {
-          "version": "0.1.3",
-          "from": "pg-connection-string@0.1.3",
-          "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz"
+          "version": "0.1.3"
         },
         "pg-types": {
-          "version": "1.6.0",
-          "from": "pg-types@1.6.0",
-          "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-1.6.0.tgz"
+          "version": "1.6.0"
         },
         "pgpass": {
           "version": "0.0.3",
-          "from": "pgpass@0.0.3",
-          "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-0.0.3.tgz",
           "dependencies": {
             "split": {
               "version": "0.3.3",
-              "from": "split@>=0.3.0 <0.4.0",
-              "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
               "dependencies": {
                 "through": {
-                  "version": "2.3.7",
-                  "from": "through@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
+                  "version": "2.3.7"
                 }
               }
             }
           }
         },
         "semver": {
-          "version": "4.3.3",
-          "from": "semver@>=4.1.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.3.tgz"
+          "version": "4.3.3"
         }
       }
     },
     "waterline-cursor": {
-      "version": "0.0.5",
-      "from": "waterline-cursor@>=0.0.5 <0.1.0",
-      "resolved": "https://registry.npmjs.org/waterline-cursor/-/waterline-cursor-0.0.5.tgz"
+      "version": "0.0.5"
     },
     "waterline-errors": {
-      "version": "0.10.1",
-      "from": "waterline-errors@>=0.10.0 <0.11.0",
-      "resolved": "https://registry.npmjs.org/waterline-errors/-/waterline-errors-0.10.1.tgz"
+      "version": "0.10.1"
     },
     "waterline-sequel": {
       "version": "0.1.1",
-      "from": "git://github.com/Shyp/waterline-sequel.git#0.1.1-milliseconds-fix",
       "resolved": "git://github.com/Shyp/waterline-sequel.git#d995c1b648f670c2728dfba5c37336d4bf26cb4a"
     }
   }

--- a/package.json
+++ b/package.json
@@ -3,12 +3,14 @@
   "description": "a postgreSQL adapter for Waterline and Sails.js",
   "version": "0.10.15",
   "author": "Cody Stoltman <particlebanana@gmail.com>",
-  "contributors": [{
+  "contributors": [
+    {
       "name": "Shyp Engineering",
       "email": "engineering@shyp.com",
       "url": "https://shyp.github.io"
-  }],
-  "url": "https://github.com/balderdashy/sails-postgresql",
+    }
+  ],
+  "url": "https://github.com/Shyp/sails-postgresql",
   "keywords": [
     "postgresql",
     "orm",
@@ -20,18 +22,18 @@
     "url": "git://github.com/Shyp/sails-postgresql.git"
   },
   "dependencies": {
-    "pg": "~4.2.0",
-    "lodash": "~2.4.1",
-    "async": "~0.9.0",
-    "waterline-errors": "~0.10.0",
-    "waterline-sequel": "git+https://github.com/Shyp/waterline-sequel.git#0.1.1-milliseconds-fix",
-    "waterline-cursor": "~0.0.5"
+    "async": "0.9.0",
+    "lodash": "2.4.1",
+    "pg": "4.2.0",
+    "waterline-cursor": "0.0.5",
+    "waterline-errors": "0.10.1",
+    "waterline-sequel": "git+https://github.com/Shyp/waterline-sequel.git#0.1.1-milliseconds-fix"
   },
   "devDependencies": {
-    "mocha": "*",
-    "should": "*",
-    "waterline-adapter-tests": "~0.10.7",
-    "captains-log": "~0.11.1"
+    "captains-log": "0.11.11",
+    "mocha": "2",
+    "should": "8",
+    "waterline-adapter-tests": "git+https://github.com/Shyp/waterline-adapter-tests.git#v1.0.0"
   },
   "scripts": {
     "test": "make test"
@@ -41,7 +43,7 @@
     "lib": "./lib"
   },
   "license": "MIT",
-  "bugs": "https://github.com/balderdashy/sails-postgresql/issues",
+  "bugs": "https://github.com/Shyp/sails-postgresql/issues",
   "waterlineAdapter": {
     "waterlineVersion": "~0.10.0",
     "interfaces": [


### PR DESCRIPTION
- Alphabetize dependencies and `devDependencies`
- Lock async at 0.9.0
- Lock pg at 4.2.0 (will be upgraded to 4.3.0 to match `api` shortly)
- Lock mocha and should major versions
- Use correct version number in npm shrinkwrap
- Use `clingwrap npmbegone` to remove shrinkwrap crud.
