### PR TITLE
Upgrade pg to 4.3.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,15 @@ test-load:
 		--reporter $(REPORTER) \
 		$(MOCHA_OPTS) \
 		test/load/**
+
+shrinkwrap:
+	rm -rf node_modules
+	npm cache clear
+	npm install --production
+	npm shrinkwrap
+	npm install --production
+	npm shrinkwrap
+	clingwrap npmbegone
+
+clean: 
+	rm -rf node_modules

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9,7 +9,7 @@
       "version": "2.4.1"
     },
     "pg": {
-      "version": "4.2.0",
+      "version": "4.3.0",
       "dependencies": {
         "buffer-writer": {
           "version": "1.0.0"
@@ -24,7 +24,7 @@
           "version": "0.1.3"
         },
         "pg-types": {
-          "version": "1.6.0"
+          "version": "1.7.0"
         },
         "pgpass": {
           "version": "0.0.3",
@@ -40,7 +40,7 @@
           }
         },
         "semver": {
-          "version": "4.3.3"
+          "version": "4.3.6"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -24,14 +24,16 @@
   "dependencies": {
     "async": "0.9.0",
     "lodash": "2.4.1",
-    "pg": "4.2.0",
+    "pg": "4.3.0",
     "waterline-cursor": "0.0.5",
     "waterline-errors": "0.10.1",
     "waterline-sequel": "git+https://github.com/Shyp/waterline-sequel.git#0.1.1-milliseconds-fix"
   },
   "devDependencies": {
     "captains-log": "0.11.11",
+    "clingwrap": "1.1.0",
     "mocha": "2",
+    "npm": "2",
     "should": "8",
     "waterline-adapter-tests": "git+https://github.com/Shyp/waterline-adapter-tests.git#v1.0.0"
   },


### PR DESCRIPTION
This matches the version we use in the API.

Adds clingwrap and npm as dev dependencies, we use them to generate a reliable
npm shrinkwrap file.
