### PR TITLE
Update waterline-adapter-tests version

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "mocha": "2",
     "npm": "2",
     "should": "8",
-    "waterline-adapter-tests": "git+https://github.com/Shyp/waterline-adapter-tests.git#v1.0.0"
+    "waterline-adapter-tests": "git+https://github.com/Shyp/waterline-adapter-tests.git#v1.1.0"
   },
   "scripts": {
     "test": "make test"


### PR DESCRIPTION
It's unfortunate but these two packages sort of depend on each other. Pick up
the latest version of the adapter tests.
