### PR TITLE
Point sails-postgresql at the node-postgres timeout branch

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9,13 +9,15 @@
       "version": "2.4.1"
     },
     "pg": {
-      "version": "4.3.0",
+      "version": "4.4.6",
+      "resolved": "git://github.com/Shyp/node-postgres.git#0a1a1b2e6e78269d99ea9094ab520fb42cdc9fbd",
       "dependencies": {
         "buffer-writer": {
-          "version": "1.0.0"
+          "version": "1.0.1"
         },
         "generic-pool": {
-          "version": "2.1.1"
+          "version": "2.4.0",
+          "resolved": "git://github.com/Shyp/node-pool.git#3c85b98a547980c344444349d2b469707e5c7798"
         },
         "packet-reader": {
           "version": "0.2.0"
@@ -24,7 +26,29 @@
           "version": "0.1.3"
         },
         "pg-types": {
-          "version": "1.7.0"
+          "version": "1.10.0",
+          "dependencies": {
+            "ap": {
+              "version": "0.2.0"
+            },
+            "postgres-array": {
+              "version": "1.0.0"
+            },
+            "postgres-bytea": {
+              "version": "1.0.0"
+            },
+            "postgres-date": {
+              "version": "1.0.1"
+            },
+            "postgres-interval": {
+              "version": "1.0.1",
+              "dependencies": {
+                "xtend": {
+                  "version": "4.0.1"
+                }
+              }
+            }
+          }
         },
         "pgpass": {
           "version": "0.0.3",
@@ -33,7 +57,7 @@
               "version": "0.3.3",
               "dependencies": {
                 "through": {
-                  "version": "2.3.7"
+                  "version": "2.3.8"
                 }
               }
             }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "async": "0.9.0",
     "lodash": "2.4.1",
-    "pg": "4.3.0",
+    "pg": "git://github.com/Shyp/node-postgres#timeout",
     "waterline-cursor": "0.0.5",
     "waterline-errors": "0.10.1",
     "waterline-sequel": "git+https://github.com/Shyp/waterline-sequel.git#0.1.1-milliseconds-fix"
@@ -35,7 +35,7 @@
     "mocha": "2",
     "npm": "2",
     "should": "8",
-    "waterline-adapter-tests": "git+https://github.com/Shyp/waterline-adapter-tests.git#v1.1.0"
+    "waterline-adapter-tests": "git+https://github.com/Shyp/waterline-adapter-tests.git#v1.2.0"
   },
   "scripts": {
     "test": "make test"


### PR DESCRIPTION
This branch lets us set an acquire timeout - a maximum amount of time to wait
for a database connection to become available - before giving up and returning
an error to the caller.
