### PR TITLE
Update waterline-sequel to v1.0.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,13 @@ REPORTER = dot
 test: test-unit test-integration
 
 test-unit:
-	@NODE_ENV=test ./node_modules/.bin/mocha \
+	@NODE_ENV=test TZ=GMT ./node_modules/.bin/mocha \
 		--reporter $(REPORTER) \
 		$(MOCHA_OPTS) \
 		test/unit/**
 
 test-integration:
-	@NODE_ENV=test node test/integration/runner.js
+	@NODE_ENV=test TZ=GMT node test/integration/runner.js
 
 test-load:
 	@NODE_ENV=test ./node_modules/.bin/mocha \

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -75,8 +75,8 @@
       "version": "0.10.1"
     },
     "waterline-sequel": {
-      "version": "0.1.1",
-      "resolved": "git://github.com/Shyp/waterline-sequel.git#d995c1b648f670c2728dfba5c37336d4bf26cb4a"
+      "version": "1.0.0",
+      "resolved": "git+https://github.com/Shyp/waterline-sequel.git#a96b06663f49c94789051ef0ba7eca0d0647774f"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "pg": "git://github.com/Shyp/node-postgres#timeout",
     "waterline-cursor": "0.0.5",
     "waterline-errors": "0.10.1",
-    "waterline-sequel": "git+https://github.com/Shyp/waterline-sequel.git#0.1.1-milliseconds-fix"
+    "waterline-sequel": "git+https://github.com/Shyp/waterline-sequel.git#v1.0.0"
   },
   "devDependencies": {
     "captains-log": "0.11.11",

--- a/test/integration/runner.js
+++ b/test/integration/runner.js
@@ -59,7 +59,7 @@ new TestRunner({
 
   // Mocha opts
   mocha: {
-    bail: false
+    bail: process.env.BAIL === 'true',
   },
 
   // Load the adapter module.

--- a/test/unit/adapter.define.js
+++ b/test/unit/adapter.define.js
@@ -65,7 +65,7 @@ describe('adapter', function() {
           support.Client(function(err, client, close) {
             var query = "SELECT attnotnull FROM pg_attribute WHERE " +
               "attrelid = 'test_define'::regclass AND attname = 'name'";
-            
+
             client.query(query, function(err, result) {
               result.rows[0].attnotnull.should.eql(true);
               close();
@@ -96,8 +96,12 @@ describe('adapter', function() {
       it('should escape reserved words', function(done) {
 
         adapter.define('test', 'user', definition, function(err) {
+          if (err) {
+            done(err);
+            return;
+          }
           adapter.describe('test', 'user', function(err, result) {
-            Object.keys(result).length.should.eql(8);
+            Object.keys(result).length.should.eql(8, JSON.stringify(result) + "\n" + JSON.stringify(err));
             done();
           });
         });


### PR DESCRIPTION
This pulls in
https://github.com/Shyp/waterline-sequel/compare/0.1.1-milliseconds-fix...v1.0.0,
which prevents UPDATE queries that include a primary key as part of the field
to be updated.
