### PR TITLE
Remove special unique error handling

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -1139,33 +1139,10 @@ module.exports = (function() {
    * @api private
    */
   function handleQueryError (err) {
-
-    var formattedErr;
-
-    // Check for uniqueness constraint violations:
-    if (err.code === '23505') {
-
-      // Manually parse the error response and extract the relevant bits,
-      // then build the formatted properties that will be passed directly to
-      // WLValidationError in Waterline core.
-      var matches = err.detail.match(/Key \((.*)\)=\((.*)\) already exists\.$/);
-      if (matches && matches.length) {
-        formattedErr = {};
-        // Preserve the original Postgres error. This property is set for
-        // WLErrors, but not currently for WLValidationErrors. It gets passed
-        // through and set on the error object in the callback to the error
-        // function
-        formattedErr.originalError = err;
-        formattedErr.code = 'E_UNIQUE';
-        formattedErr.invalidAttributes = {};
-        formattedErr.invalidAttributes[matches[1]] = [{
-          value: matches[2],
-          rule: 'unique'
-        }];
-      }
-    }
-
-    return formattedErr || err;
+    // For legacy purposes, attach the Postgres error as the `originalError`
+    // property; clients are expecting to find Postgres error objects there.
+    err.originalError = err;
+    return err;
   }
 
   return adapter;


### PR DESCRIPTION
The recent changes to Waterline's error handling mean we are returning a
single, better error from the client - it's easier to just pass back the raw
message that Postgres gives us, and not apply any error handling or formatting
to it.
