### PR TITLE
Report unique constraint failures as E_UNIQUE errors

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -1133,7 +1133,6 @@ module.exports = (function() {
   }
 
   /**
-   *
    * @param  {[type]} err [description]
    * @return {[type]}     [description]
    * @api private
@@ -1142,6 +1141,9 @@ module.exports = (function() {
     // For legacy purposes, attach the Postgres error as the `originalError`
     // property; clients are expecting to find Postgres error objects there.
     err.originalError = err;
+    if (err.originalError.code === '23505') {
+      err.code = 'E_UNIQUE';
+    }
     return err;
   }
 


### PR DESCRIPTION
This triggers a different code path in Waterline and reports these unique
constraint failures as WLValidationErrors, not WLErrors.
