### PR TITLE
Remove custom query handler altogether

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -152,12 +152,12 @@ module.exports = (function() {
 
         // Run Info Query
         client.query(query, function(err, result) {
-          if(err) return cb(handleQueryError(err));
+          if(err) return cb(err);
           if(result.rows.length === 0) return cb();
 
           // Run Query to get Auto Incrementing sequences
           client.query(autoIncrementQuery, function(err, aResult) {
-            if(err) return cb(handleQueryError(err));
+            if(err) return cb(err);
 
             aResult.rows.forEach(function(row) {
               if(row.related_table !== table) return;
@@ -171,7 +171,7 @@ module.exports = (function() {
 
             // Run Query to get Indexed values
             client.query(indiciesQuery, function(err, iResult) {
-              if(err) return cb(handleQueryError(err));
+              if(err) return cb(err);
 
               // Loop through indicies and see if any match
               iResult.rows.forEach(function(column) {
@@ -227,7 +227,7 @@ module.exports = (function() {
 
         // Run Query
         client.query(query, function __DEFINE__(err, result) {
-          if(err) return cb(handleQueryError(err));
+          if(err) return cb(err);
 
           // Build Indexes
           function buildIndex(name, cb) {
@@ -240,7 +240,7 @@ module.exports = (function() {
 
             // Run Query
             client.query(query, function(err, result) {
-              if(err) return cb(handleQueryError(err));
+              if(err) return cb(err);
               cb();
             });
           }
@@ -301,7 +301,7 @@ module.exports = (function() {
 
         // Run Query
         client.query(query, function __ADD_ATTRIBUTE__(err, result) {
-          if(err) return cb(handleQueryError(err));
+          if(err) return cb(err);
           cb(null, result.rows);
         });
 
@@ -320,7 +320,7 @@ module.exports = (function() {
 
         // Run Query
         client.query(query, function __REMOVE_ATTRIBUTE__(err, result) {
-          if(err) return cb(handleQueryError(err));
+          if(err) return cb(err);
           cb(null, result.rows);
         });
 
@@ -369,7 +369,7 @@ module.exports = (function() {
 
         // Run Query
         client.query(query.query, query.values, function __CREATE__(err, result) {
-          if(err) return cb(handleQueryError(err));
+          if(err) return cb(err);
 
           // Cast special values
           var values = processor.cast(table, result.rows[0]);
@@ -454,7 +454,7 @@ module.exports = (function() {
 
           // Run Query
           client.query(query.query, query.values, function __CREATE_EACH__(err, result) {
-            if(err) return cb(handleQueryError(err));
+            if(err) return cb(err);
 
             // Cast special values
             var values = processor.cast(table, result.rows[0]);
@@ -589,7 +589,7 @@ module.exports = (function() {
               processParent: function(next) {
 
                 client.query(_query.query[0], _query.values[0], function __FIND__(err, result) {
-                  if(err) return next(handleQueryError(err));
+                  if(err) return next(err);
 
                   parentRecords = result.rows;
 
@@ -729,7 +729,7 @@ module.exports = (function() {
                     qs = qs.slice(0, -2);
                   }
                   client.query(qs, q.values, function __FIND__(err, result) {
-                    if(err) return next(handleQueryError(err));
+                    if(err) return next(err);
 
                     var groupedRecords = {};
 
@@ -826,7 +826,7 @@ module.exports = (function() {
         }
 
         client.query(_query.query[0], _query.values[0], function __FIND__(err, result) {
-          if(err) return cb(handleQueryError(err));
+          if(err) return cb(err);
 
           // Cast special values
           var values = [];
@@ -910,7 +910,7 @@ module.exports = (function() {
 
         // Run Query
         client.query(query.query, query.values, function __UPDATE__(err, result) {
-          if(err) return cb(handleQueryError(err));
+          if(err) return cb(err);
 
           // Cast special values
           var values = [];
@@ -953,7 +953,7 @@ module.exports = (function() {
 
         // Run Query
         client.query(query.query, query.values, function __DELETE__(err, result) {
-          if(err) return cb(handleQueryError(err));
+          if(err) return cb(err);
           cb(null, result.rows);
         });
 
@@ -1130,21 +1130,6 @@ module.exports = (function() {
         return cb(err, result);
       });
     }
-  }
-
-  /**
-   * @param  {[type]} err [description]
-   * @return {[type]}     [description]
-   * @api private
-   */
-  function handleQueryError (err) {
-    // For legacy purposes, attach the Postgres error as the `originalError`
-    // property; clients are expecting to find Postgres error objects there.
-    err.originalError = err;
-    if (err.originalError.code === '23505') {
-      err.code = 'E_UNIQUE';
-    }
-    return err;
   }
 
   return adapter;


### PR DESCRIPTION
It's easier to just handle Postgres errors in Waterline, which we can do now
since Waterline's only supported backend is Postgres.

The alternative would be to move all of the error handling into here but we
can't do that because Waterline performs validation and returns some errors
without ever hitting sails-postgresql, so defer all of the error handling
there.
