### PR TITLE
Install and use pg-native.

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -4,7 +4,7 @@
 ---------------------------------------------------------------*/
 
 // Dependencies
-var pg = require('pg');
+var pg = require('pg').native;
 var _ = require('lodash');
 var url = require('url');
 var async = require('async');

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -75,6 +75,42 @@
     "waterline-sequel": {
       "version": "0.1.1",
       "resolved": "git://github.com/Shyp/waterline-sequel.git#d995c1b648f670c2728dfba5c37336d4bf26cb4a"
+    },
+    "pg-native": {
+      "version": "1.10.0",
+      "dependencies": {
+        "libpq": {
+          "version": "1.8.1",
+          "dependencies": {
+            "nan": {
+              "version": "2.2.0"
+            },
+            "bindings": {
+              "version": "1.2.1"
+            }
+          }
+        },
+        "pg-types": {
+          "version": "1.6.0"
+        },
+        "readable-stream": {
+          "version": "1.0.31",
+          "dependencies": {
+            "core-util-is": {
+              "version": "1.0.2"
+            },
+            "isarray": {
+              "version": "0.0.1"
+            },
+            "string_decoder": {
+              "version": "0.10.31"
+            },
+            "inherits": {
+              "version": "2.0.1"
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "async": "0.9.0",
     "lodash": "2.4.1",
     "pg": "4.3.0",
+    "pg-native": "1.10.0",
     "waterline-cursor": "0.0.5",
     "waterline-errors": "0.10.1",
     "waterline-sequel": "git+https://github.com/Shyp/waterline-sequel.git#0.1.1-milliseconds-fix"

--- a/test/unit/support/bootstrap.js
+++ b/test/unit/support/bootstrap.js
@@ -2,7 +2,7 @@
  * Support functions for helping with Postgres tests
  */
 
-var pg = require('pg'),
+var pg = require('pg').native,
     _ = require('lodash'),
     adapter = require('../../../lib/adapter');
 


### PR DESCRIPTION
pg-native is a wrapper around the native bindings, which are supposed to be able to parse 20-30% faster, which is a Good Thing™.

Instructions pulled from https://github.com/brianc/node-postgres#native-bindings
