### PR TITLE
Add The Ability To Capture Connection Metrics

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -1044,6 +1044,10 @@ module.exports = (function() {
         // Ignore; we can't capture these metrics
       }
 
+      // Reset so that the release latency metric isn't polluted by the "get"
+      // latency
+      start = new Date();
+
       after(err, client, done);
     });
 

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -15,6 +15,12 @@ var Processor = require('./processor');
 var Cursor = require('waterline-cursor');
 var hop = utils.object.hasOwnProperty;
 
+var DEFAULT_METRICS = {
+  increment: function(name, value) {},
+  measure: function(name, value) {},
+  timing: function(name, startTime) {},
+};
+
 module.exports = (function() {
 
   // Keep track of all the connections used by the app
@@ -997,8 +1003,6 @@ module.exports = (function() {
     }
   }
 
-
-
   // Wrap a function in the logic necessary to provision a connection
   // (grab from the pool or create a client)
   function spawnConnection(connectionName, logic, cb) {
@@ -1015,8 +1019,31 @@ module.exports = (function() {
       connectionConfig = url.format(connectionUrl);
     }
 
+    var metrics = DEFAULT_METRICS;
+    var metricsPrefix = 'sails-postgres.' + connectionName + '.';
+
+    if (_.has(connectionConfig, 'metrics')) {
+      metrics = connectionConfig.metrics;
+    }
+
+    var start = new Date();
+
     // Grab a client instance from the client pool
     pg.connect(connectionConfig, function(err, client, done) {
+      // Wrap all metrics collection in a try/catch so that a misconfiguration
+      // doesn't take the application down.
+      try {
+        metrics.timing(metricsPrefix + 'connection.get.latency', start);
+        metrics.increment(metricsPrefix + 'connection.get');
+
+        pool = pg.pools.all[JSON.stringify(connectionConfig)];
+        metrics.measure(metricsPrefix + 'pool.available', pool.availableObjectsCount());
+        metrics.measure(metricsPrefix + 'pool.size', pool.getPoolSize());
+        metrics.measure(metricsPrefix + 'pool.waiting', pool.waitingClientsCount());
+      } catch (err) {
+        // Ignore; we can't capture these metrics
+      }
+
       after(err, client, done);
     });
 
@@ -1124,6 +1151,11 @@ module.exports = (function() {
       }
 
       logic(client, function(err, result) {
+        try {
+          metrics.timing(metricsPrefix + 'connection.release.latency', start);
+        } catch (err) {
+          // Ignore, we can't capture metrics
+        }
 
         // release client connection
         done();

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -1036,7 +1036,7 @@ module.exports = (function() {
         metrics.timing(metricsPrefix + 'connection.get.latency', start);
         metrics.increment(metricsPrefix + 'connection.get');
 
-        pool = pg.pools.all[JSON.stringify(connectionConfig)];
+        var pool = pg.pools.all[JSON.stringify(connectionConfig)];
         metrics.measure(metricsPrefix + 'pool.available', pool.availableObjectsCount());
         metrics.measure(metricsPrefix + 'pool.size', pool.getPoolSize());
         metrics.measure(metricsPrefix + 'pool.waiting', pool.waitingClientsCount());

--- a/test/unit/adapter.metrics.js
+++ b/test/unit/adapter.metrics.js
@@ -1,0 +1,82 @@
+var adapter = require('../../lib/adapter'),
+    should = require('should'),
+    support = require('./support/bootstrap');
+
+describe('adapter', function() {
+  context('when default no-op metrics are configured', function() {
+    before(function(done) {
+      support.Setup('test_metrics', done);
+    });
+
+    after(function(done) {
+      support.Teardown('test_metrics', done);
+    });
+
+    describe('.spawnConnection()', function() {
+      it('does not throw', function(done) {
+        adapter.find('test', 'test_metrics', { where: { field_1: 'foo' } }, function(err, results) {
+          should(err).eql(null);
+          done();
+        });
+      });
+    });
+  });
+
+  context('when custom metrics are configured', function() {
+    var metrics;
+    var originalConfig;
+
+    /**
+     * Setup and Teardown
+     */
+    before(function(done) {
+      originalConfig = support.Config;
+
+      metrics = {
+        increments: [],
+        measures: [],
+        timings: [],
+
+        configure: function(opts) {},
+        namespace: function(name) { return name; },
+        increment: function(name, value) {
+          metrics.increments.push({
+            name: name,
+            value: value,
+          });
+        },
+        measure: function(name, value) {
+          metrics.measures.push({
+            name: name,
+            value: value,
+          });
+        },
+        timing: function(name, startTime) {
+          metrics.timings.push({
+            name: name,
+            startTime: startTime,
+          });
+        },
+      };
+
+      support.Config.metrics = metrics;
+      support.Setup('test_metrics', done);
+    });
+
+    after(function(done) {
+      support.Config = originalConfig;
+      support.Teardown('test_metrics', done);
+    });
+
+    describe('.spawnConnection()', function() {
+      it('captures metrics', function(done) {
+        adapter.find('test', 'test_metrics', { where: { field_1: 'foo' } }, function(err, results) {
+          metrics.increments.length.should.eql(4);
+          metrics.measures.length.should.eql(12);
+          metrics.timings.length.should.eql(8);
+          done();
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
A sails-postgresql config can now supply a `metrics` object that, when
present, will be used to capture run-time connection metrics. The
`metrics` object _must_ have the following functions:
- `increment(name, value)`
- `measure(name, value)`
- `timing(name, startTime)`
