### PR TITLE
Upgrade waterline-sequel to v1.2.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -73,8 +73,8 @@
       "version": "0.10.1"
     },
     "waterline-sequel": {
-      "version": "0.1.1",
-      "resolved": "git://github.com/Shyp/waterline-sequel.git#d995c1b648f670c2728dfba5c37336d4bf26cb4a"
+      "version": "1.2.0",
+      "resolved": "git+https://github.com/Shyp/waterline-sequel.git#704020a5644e6470864a0b7ed666daa7beac660e"
     },
     "pg-native": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "pg-native": "1.10.0",
     "waterline-cursor": "0.0.5",
     "waterline-errors": "0.10.1",
-    "waterline-sequel": "git+https://github.com/Shyp/waterline-sequel.git#0.1.1-milliseconds-fix"
+    "waterline-sequel": "git+https://github.com/Shyp/waterline-sequel.git#v1.2.0"
   },
   "devDependencies": {
     "captains-log": "0.11.11",
@@ -36,7 +36,7 @@
     "mocha": "2",
     "npm": "2",
     "should": "8",
-    "waterline-adapter-tests": "git+https://github.com/Shyp/waterline-adapter-tests.git#v1.9.0"
+    "waterline-adapter-tests": "git+https://github.com/Shyp/waterline-adapter-tests.git#v1.10.0"
   },
   "scripts": {
     "test": "make test"


### PR DESCRIPTION
This change stops putting the word "undefined" in generated queries, and throws
an error instead.

Diff: https://github.com/shyp/waterline-sequel/compare/704020a5644e6470864a0b7ed666daa7beac660e...v1.2.0
