### PR TITLE
Upgrade waterline-adapter-tests to v1.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "mocha": "2",
     "npm": "2",
     "should": "8",
-    "waterline-adapter-tests": "git+https://github.com/Shyp/waterline-adapter-tests.git#v1.2.0"
+    "waterline-adapter-tests": "git+https://github.com/Shyp/waterline-adapter-tests.git#v1.9.0"
   },
   "scripts": {
     "test": "make test"


### PR DESCRIPTION
This version of the tests contains a lot of fixes for new behavior in
Waterline, and even more Postgres-specific logic.

Diff: https://github.com/Shyp/waterline-adapter-tests/compare/v1.2.0...v1.9.0
