### PR TITLE
Remove pg-native

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -4,7 +4,7 @@
 ---------------------------------------------------------------*/
 
 // Dependencies
-var pg = require('pg').native;
+var pg = require('pg');
 var _ = require('lodash');
 var url = require('url');
 var async = require('async');

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -75,42 +75,6 @@
     "waterline-sequel": {
       "version": "1.2.0",
       "resolved": "git+https://github.com/Shyp/waterline-sequel.git#704020a5644e6470864a0b7ed666daa7beac660e"
-    },
-    "pg-native": {
-      "version": "1.10.0",
-      "dependencies": {
-        "libpq": {
-          "version": "1.8.1",
-          "dependencies": {
-            "nan": {
-              "version": "2.2.0"
-            },
-            "bindings": {
-              "version": "1.2.1"
-            }
-          }
-        },
-        "pg-types": {
-          "version": "1.6.0"
-        },
-        "readable-stream": {
-          "version": "1.0.31",
-          "dependencies": {
-            "core-util-is": {
-              "version": "1.0.2"
-            },
-            "isarray": {
-              "version": "0.0.1"
-            },
-            "string_decoder": {
-              "version": "0.10.31"
-            },
-            "inherits": {
-              "version": "2.0.1"
-            }
-          }
-        }
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "async": "0.9.0",
     "lodash": "2.4.1",
     "pg": "4.3.0",
-    "pg-native": "1.10.0",
     "waterline-cursor": "0.0.5",
     "waterline-errors": "0.10.1",
     "waterline-sequel": "git+https://github.com/Shyp/waterline-sequel.git#v1.2.0"
@@ -36,7 +35,7 @@
     "mocha": "2",
     "npm": "2",
     "should": "8",
-    "waterline-adapter-tests": "git+https://github.com/Shyp/waterline-adapter-tests.git#v1.10.0"
+    "waterline-adapter-tests": "git+https://github.com/Shyp/waterline-adapter-tests.git#v1.11.0"
   },
   "scripts": {
     "test": "make test"

--- a/test/unit/support/bootstrap.js
+++ b/test/unit/support/bootstrap.js
@@ -2,7 +2,7 @@
  * Support functions for helping with Postgres tests
  */
 
-var pg = require('pg').native,
+var pg = require('pg'),
     _ = require('lodash'),
     adapter = require('../../../lib/adapter');
 


### PR DESCRIPTION
This change requires a lot of work to achieve API compatibility with
node-postgres, at the very least there's a report of a problem with connection
pools, in addition the error objects have a completely different format in
pg-native.
- https://github.com/brianc/node-pg-native/issues/46
- https://github.com/brianc/node-postgres/issues/972
