### PR TITLE
Mark the database as dirty when a record is inserted

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,18 @@
 .PHONY: clean install test test-integration test-unit shrinkwrap
 
-MOCHA_OPTS= --check-leaks
+MOCHA_OPTS= --check-leaks --globals DBRecordsInserted
 REPORTER = dot
 
 test: test-unit test-integration
 
 test-unit:
-	@NODE_ENV=test ./node_modules/.bin/mocha \
+	@NODE_ENV=test TZ=GMT ./node_modules/.bin/mocha \
 		--reporter $(REPORTER) \
 		$(MOCHA_OPTS) \
 		test/unit/**
 
 test-integration:
-	@NODE_ENV=test node test/integration/runner.js
+	@NODE_ENV=test TZ=GMT node test/integration/runner.js
 
 test-load:
 	@NODE_ENV=test ./node_modules/.bin/mocha \
@@ -40,4 +40,3 @@ circle-install:
 	curl --remote-name https://raw.githubusercontent.com/Shyp/set-node-npm/master/set-node-npm
 	chmod +x set-node-npm
 	./set-node-npm
-

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -471,7 +471,16 @@ module.exports = (function() {
 
           // Run Query
           client.query(query.query, query.values, function __CREATE_EACH__(err, result) {
-            if(err) return cb(err);
+            if (err) {
+              return cb(err);
+            }
+
+            // Use this in tests to detect whether a test inserted rows into the
+            // database. After you clear the database, reset DBRecordsInserted to
+            // false.
+            if (process.env.NODE_ENV === 'test' && result.rows.length > 0) {
+              global.DBRecordsInserted = true;
+            }
 
             // Cast special values
             var values = processor.cast(table, result.rows[0]);

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -350,7 +350,7 @@ module.exports = (function() {
         // Mixin WL Next connection overrides to sqlOptions
         var overrides = connectionOverrides[connectionName] || {};
         var options = _.cloneDeep(sqlOptions);
-        if(hop(overrides, 'wlNext')) {
+        if (hop(overrides, 'wlNext')) {
           options.wlNext = overrides.wlNext;
         }
 
@@ -375,7 +375,16 @@ module.exports = (function() {
 
         // Run Query
         client.query(query.query, query.values, function __CREATE__(err, result) {
-          if(err) return cb(err);
+          if (err) {
+            return cb(err);
+          }
+
+          // Use this in tests to detect whether a test inserted rows into the
+          // database. After you clear the database, reset DBRecordsInserted to
+          // false.
+          if (process.env.NODE_ENV === 'test' && result.rows.length > 0) {
+            global.DBRecordsInserted = true;
+          }
 
           // Cast special values
           var values = processor.cast(table, result.rows[0]);
@@ -395,7 +404,9 @@ module.exports = (function() {
           }
 
           async.each(incrementSequences, setSequence, function(err) {
-            if(err) return cb(err);
+            if (err) {
+              return cb(err);
+            }
             cb(null, values);
           });
 
@@ -404,7 +415,7 @@ module.exports = (function() {
       }, cb);
     },
 
-    // Add a multiple rows to the table
+    // Add multiple rows to the table
     createEach: function(connectionName, table, records, cb) {
 
       // Don't bother if there are no records to create.


### PR DESCRIPTION
Currently we attempt to clear the database after every Shyp API test. However,
we only need to clear the database if we inserted records! If we can add logic
here and in DBConnection to check when the database is dirty, we can save a
database round trip between a large number of our tests.
