### PR TITLE
Upgrade node-postgres to v4.6.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9,13 +9,14 @@
       "version": "2.4.1"
     },
     "pg": {
-      "version": "4.3.0",
+      "version": "4.6.0",
+      "resolved": "git+https://github.com/Shyp/node-postgres.git#ad666e194f3784d169fc90fce7a110a242af52f5",
       "dependencies": {
         "buffer-writer": {
-          "version": "1.0.0"
+          "version": "1.0.1"
         },
-        "generic-pool": {
-          "version": "2.1.1"
+        "generic-pool-timeout": {
+          "version": "2.7.1"
         },
         "packet-reader": {
           "version": "0.2.0"
@@ -24,7 +25,7 @@
           "version": "0.1.3"
         },
         "pg-types": {
-          "version": "1.10.0",
+          "version": "1.11.0",
           "dependencies": {
             "ap": {
               "version": "0.2.0"
@@ -36,10 +37,10 @@
               "version": "1.0.0"
             },
             "postgres-date": {
-              "version": "1.0.1"
+              "version": "1.0.2"
             },
             "postgres-interval": {
-              "version": "1.0.1",
+              "version": "1.0.2",
               "dependencies": {
                 "xtend": {
                   "version": "4.0.1"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "async": "0.9.0",
     "lodash": "2.4.1",
-    "pg": "4.3.0",
+    "pg": "git+https://github.com/Shyp/node-postgres.git#v4.6.0",
     "waterline-cursor": "0.0.5",
     "waterline-errors": "0.10.1",
     "waterline-sequel": "git+https://github.com/Shyp/waterline-sequel.git#v1.2.0"
@@ -35,7 +35,7 @@
     "mocha": "2",
     "npm": "2",
     "should": "8",
-    "waterline-adapter-tests": "git+https://github.com/Shyp/waterline-adapter-tests.git#v1.11.0"
+    "waterline-adapter-tests": "git+https://github.com/Shyp/waterline-adapter-tests.git#v1.12.0"
   },
   "scripts": {
     "test": "make test"


### PR DESCRIPTION
This version lets us timeout resource acquisition - if the timeout hits before
a connection becomes available, let's hit the callback with an error.

Diffs:
- https://github.com/shyp/node-postgres/compare/v4.3.0...v4.6.0
- https://github.com/kevinburke/generic-pool-timeout/compare/v2.1.1...v2.7.1
